### PR TITLE
5.0.11.89391 ptr

### DIFF
--- a/mods/voidmulti.sc2mod/base.sc2data/gamedata/abildata.xml
+++ b/mods/voidmulti.sc2mod/base.sc2data/gamedata/abildata.xml
@@ -86,6 +86,9 @@
     </CAbilArmMagazine>
     <CAbilEffectTarget id="BuildAutoTurret">
         <Range index="0" value="2"/>
+        <Cost index="0">
+            <Vital index="Energy" value="75"/>
+        </Cost>
     </CAbilEffectTarget>
     <CAbilBuild id="BuildNydusCanal">
         <InfoArray index="Build1">
@@ -119,6 +122,11 @@
         <CmdButtonArray index="Execute">
             <Flags index="ShowInGlossary" value="0"/>
         </CmdButtonArray>
+        <InfoArray index="0">
+            <SectionArray index="Stats">
+                <DurationArray index="Duration" value="0"/>
+            </SectionArray>
+        </InfoArray>
     </CAbilMorph>
     <CAbilMorph id="BurrowHydraliskDown">
         <Flags index="IgnoreFood" value="1"/>
@@ -133,7 +141,7 @@
                 <DurationArray index="Duration" value="0.5"/>
             </SectionArray>
             <SectionArray index="Stats">
-                <DurationArray index="Duration" value="0.2221"/>
+                <DurationArray index="Duration" value="0"/>
             </SectionArray>
         </InfoArray>
         <Flags index="IgnoreFood" value="1"/>
@@ -169,11 +177,20 @@
         <CmdButtonArray index="Execute">
             <Flags index="ShowInGlossary" value="0"/>
         </CmdButtonArray>
+        <InfoArray index="0">
+            <SectionArray index="Stats">
+                <DurationArray index="Duration" value="0"/>
+            </SectionArray>
+        </InfoArray>
+    </CAbilMorph>
+    <CAbilMorph id="BurrowLurkerMPDown">
+        <InfoArray index="0" RandomDelayMax="0.125"/>
     </CAbilMorph>
     <CAbilMorph id="BurrowLurkerMPUp">
         <CmdButtonArray index="Execute">
             <Flags index="ShowInGlossary" value="0"/>
         </CmdButtonArray>
+        <InfoArray index="0" RandomDelayMax="0"/>
     </CAbilMorph>
     <CAbilMorph id="BurrowQueenDown">
         <Flags index="IgnoreFood" value="1"/>
@@ -188,6 +205,11 @@
         <CmdButtonArray index="Execute">
             <Flags index="ShowInGlossary" value="0"/>
         </CmdButtonArray>
+        <InfoArray index="0">
+            <SectionArray index="Stats">
+                <DurationArray index="Duration" value="0"/>
+            </SectionArray>
+        </InfoArray>
     </CAbilMorph>
     <CAbilMorph id="BurrowRavagerDown">
         <Flags index="IgnoreFood" value="1"/>
@@ -202,6 +224,11 @@
         <CmdButtonArray index="Execute">
             <Flags index="ShowInGlossary" value="0"/>
         </CmdButtonArray>
+        <InfoArray index="0">
+            <SectionArray index="Stats">
+                <DurationArray index="Duration" value="0"/>
+            </SectionArray>
+        </InfoArray>
     </CAbilMorph>
     <CAbilMorph id="BurrowRoachDown">
         <Flags index="IgnoreFood" value="1"/>
@@ -216,6 +243,11 @@
         <CmdButtonArray index="Execute">
             <Flags index="ShowInGlossary" value="0"/>
         </CmdButtonArray>
+        <InfoArray index="0">
+            <SectionArray index="Stats">
+                <DurationArray index="Duration" value="0"/>
+            </SectionArray>
+        </InfoArray>
     </CAbilMorph>
     <CAbilMorph id="BurrowUltraliskDown">
         <Flags index="IgnoreFood" value="1"/>
@@ -236,19 +268,19 @@
         <Flags index="IgnoreUnitCost" value="1"/>
     </CAbilMorph>
     <CAbilMorph id="BurrowZerglingUp">
+        <CmdButtonArray index="Execute">
+            <Flags index="ShowInGlossary" value="0"/>
+        </CmdButtonArray>
+        <Flags index="IgnoreFood" value="1"/>
+        <Flags index="IgnoreUnitCost" value="1"/>
         <InfoArray index="0" RandomDelayMax="0.1125">
             <SectionArray index="Abils">
-                <DurationArray index="Delay" value="0.5625"/>
+                <DurationArray index="Delay" value="0"/>
             </SectionArray>
             <SectionArray index="Actor">
                 <DurationArray index="Duration" value="0.5"/>
             </SectionArray>
         </InfoArray>
-        <Flags index="IgnoreFood" value="1"/>
-        <Flags index="IgnoreUnitCost" value="1"/>
-        <CmdButtonArray index="Execute">
-            <Flags index="ShowInGlossary" value="0"/>
-        </CmdButtonArray>
     </CAbilMorph>
     <CAbilEffectTarget id="CalldownMULE">
         <Effect index="0" value="OrbitalCommandCreateMuleSwitch"/>
@@ -257,6 +289,13 @@
         <Flags index="AutoCast" value="1"/>
         <Flags index="AutoCastOn" value="1"/>
     </CAbilEffectTarget>
+    <CAbilBuild id="CreepTumorBuild">
+        <InfoArray index="Build1">
+            <Cooldown TimeStart="18" TimeUse="18"/>
+        </InfoArray>
+        <!--EffectArray index="Finish" value="CreepTumorLaunchMissile"/>
+        <EffectArray index="Cancel" value="CreepTumorLaunchMissile"/-->
+    </CAbilBuild>
     <CAbilResearch id="CyberneticsCoreResearch">
         <InfoArray index="Research1" Time="180"/>
         <InfoArray index="Research2" Time="215"/>
@@ -307,6 +346,7 @@
     </CAbilResearch>
     <CAbilTrain id="FactoryTrain">
         <InfoArray index="Train25" Time="30"/>
+        <Range value="3"/>
     </CAbilTrain>
     <CAbilEffectTarget id="Feedback">
         <Range index="0" value="10"/>
@@ -340,15 +380,15 @@
         </InfoArray>
     </CAbilResearch>
     <CAbilResearch id="ForgeResearch">
-        <InfoArray index="Research1" Time="180"/>
-        <InfoArray index="Research2" Time="215"/>
-        <InfoArray index="Research3" Time="250"/>
-        <InfoArray index="Research4" Time="180"/>
-        <InfoArray index="Research5" Time="215"/>
-        <InfoArray index="Research6" Time="250"/>
-        <InfoArray index="Research7" Time="180"/>
-        <InfoArray index="Research8" Time="215"/>
-        <InfoArray index="Research9" Time="250"/>
+        <InfoArray index="Research1" Time="170"/>
+        <InfoArray index="Research2" Time="200"/>
+        <InfoArray index="Research3" Time="230"/>
+        <InfoArray index="Research4" Time="170"/>
+        <InfoArray index="Research5" Time="200"/>
+        <InfoArray index="Research6" Time="230"/>
+        <InfoArray index="Research7" Time="170"/>
+        <InfoArray index="Research8" Time="200"/>
+        <InfoArray index="Research9" Time="230"/>
     </CAbilResearch>
     <CAbilEffectTarget id="FungalGrowth">
         <CmdButtonArray index="Execute">
@@ -369,6 +409,7 @@
         </InfoArray>
     </CAbilResearch>
     <CAbilTrain id="GatewayTrain">
+        <InfoArray index="Train6" Time="32"/>
         <InfoArray index="Train7" Time="42"/>
     </CAbilTrain>
     <CAbilResearch id="GhostAcademyResearch">
@@ -557,8 +598,33 @@
         <Arc value="0"/>
         <Range index="0" value="5"/>
     </CAbilEffectTarget>
+    <CAbilMorph id="LiberatorMorphtoAA">
+        <InfoArray index="0">
+            <SectionArray index="Abils">
+                <DurationArray index="Delay" value="0"/>
+            </SectionArray>
+            <SectionArray index="Mover">
+                <DurationArray index="Duration" value="0"/>
+            </SectionArray>
+            <SectionArray index="Stats">
+                <DurationArray index="Delay" value="0"/>
+            </SectionArray>
+        </InfoArray>
+    </CAbilMorph>
+    <CAbilMorph id="LiberatorMorphtoAG">
+        <InfoArray index="0">
+            <SectionArray index="Abils">
+                <DurationArray index="Delay" value="0"/>
+            </SectionArray>
+            <SectionArray index="Stats">
+                <DurationArray index="Duration" value="0"/>
+            </SectionArray>
+        </InfoArray>
+    </CAbilMorph>
     <CAbilEffectTarget id="LockOn">
         <Effect index="0" value="LockOnInitialSetNew"/>
+        <AutoCastValidatorArray value="CasterIsNotHidden"/>
+        <AutoCastValidatorArray value="NotLarvaEgg"/>
     </CAbilEffectTarget>
     <!--CAbilEffectTarget id="LockOn">
         <Flags index="AutoCast" value="0"/>
@@ -606,6 +672,8 @@
     </CAbilMorph>
     <CAbilMorph id="MorphToLurker">
         <Flags index="IgnoreFacing" value="1"/>
+        <Flags index="WaitUntilStopped" value="0"/>
+        <InfoArray index="0" RandomDelayMax="0"/>
     </CAbilMorph>
     <CAbilMorph id="MorphToOverseer">
         <Flags index="IgnoreFacing" value="1"/>
@@ -613,6 +681,19 @@
     </CAbilMorph>
     <CAbilMorph id="MorphToRavager">
         <Flags index="IgnoreFacing" value="1"/>
+        <Flags index="WaitUntilStopped" value="0"/>
+        <InfoArray index="0" RandomDelayMax="0"/>
+        <InfoArray index="1">
+            <SectionArray index="Abils">
+                <DurationArray index="Delay" value="17"/>
+            </SectionArray>
+            <SectionArray index="Actor">
+                <DurationArray index="Delay" value="17"/>
+            </SectionArray>
+            <SectionArray index="Stats">
+                <DurationArray index="Delay" value="17"/>
+            </SectionArray>
+        </InfoArray>
     </CAbilMorph>
     <CAbilMorph id="MorphToSwarmHostBurrowedMP">
         <AbilSetId value="BrwD"/>
@@ -629,6 +710,52 @@
         <CmdButtonArray index="Execute">
             <Flags index="ShowInGlossary" value="0"/>
         </CmdButtonArray>
+        <InfoArray index="0">
+            <SectionArray index="Abils">
+                <DurationArray index="Delay" value="0"/>
+            </SectionArray>
+            <SectionArray index="Actor">
+                <DurationArray index="Delay" value="0"/>
+            </SectionArray>
+            <SectionArray index="Mover">
+                <DurationArray index="Delay" value="0"/>
+                <DurationArray index="Duration" value="0"/>
+            </SectionArray>
+            <SectionArray index="Stats">
+                <DurationArray index="Delay" value="0"/>
+            </SectionArray>
+        </InfoArray>
+    </CAbilMorph>
+    <CAbilMorph id="MorphToBaneling">
+        <EditorCategories value="Race:Zerg,AbilityorEffectType:MorphsandBurrows"/>
+        <CmdButtonArray index="Execute" DefaultButtonFace="Baneling" Requirements="HaveBanelingNest"/>
+        <CmdButtonArray index="Cancel" DefaultButtonFace="Cancel"/>
+        <Flags index="BestUnit" value="1"/>
+        <Flags index="Birth" value="1"/>
+        <Flags index="DisableAbils" value="1"/>
+        <Flags index="FastBuild" value="1"/>
+        <Flags index="Interruptible" value="1"/>
+        <Flags index="IgnoreFacing" value="1"/>
+        <Flags index="Produce" value="1"/>
+        <Flags index="Rally" value="1"/>
+        <Flags index="RallyReset" value="1"/>
+        <Flags index="ShowProgress" value="1"/>
+        <Flags index="SuppressMovement" value="1"/>
+        <Flags index="WaitUntilStopped" value="0"/>
+        <InfoArray Unit="BanelingCocoon"/>
+        <InfoArray Score="1" Unit="Baneling">
+            <SectionArray index="Abils">
+                <DurationArray index="Delay" value="20"/>
+            </SectionArray>
+            <SectionArray index="Actor">
+                <DurationArray index="Delay" value="20"/>
+            </SectionArray>
+            <SectionArray index="Stats">
+                <DurationArray index="Delay" value="20"/>
+                <EffectArray index="Finish" value="PostMorphHeal"/>
+            </SectionArray>
+        </InfoArray>
+        <Alert value="MorphComplete_Zerg"/>
     </CAbilMorph>
     <CAbilEffectTarget id="MothershipCoreMassRecall">
         <Cost index="0">
@@ -756,6 +883,7 @@
         <AutoCastRange value="6"/>
         <AutoCastValidatorArray value="Casterhas10EnergyorCasterisBatteryOvercharged"/>
         <AutoCastValidatorArray value="UnitOrAttackingStructure"/>
+        <AutoCastValidatorArray value="NotHaveBatteryCooldownBehavior"/>
         <UseMarkerArray index="Approach" value="0"/>
         <UseMarkerArray index="Prep" value="0"/>
         <CancelableArray index="Channel" value="1"/>
@@ -785,6 +913,7 @@
         <Effect index="0" value="LocustMPCreateSet"/>
         <Flags index="BestUnit" value="0"/>
         <Flags index="RequireTargetVision" value="0"/>
+        <Flags index="Transient" value="1"/>
         <Cost>
             <Cooldown TimeUse="60"/>
         </Cost>
@@ -823,9 +952,9 @@
             <Resource index="Minerals" value="100"/>
             <Resource index="Vespene" value="100"/>
         </InfoArray>
-        <InfoArray index="Research10" Time="170" Upgrade="BansheeSpeed">
-            <Resource index="Minerals" value="150"/>
-            <Resource index="Vespene" value="150"/>
+        <InfoArray index="Research10" Time="140" Upgrade="BansheeSpeed">
+            <Resource index="Minerals" value="125"/>
+            <Resource index="Vespene" value="125"/>
             <Button DefaultButtonFace="BansheeSpeed" Requirements="LearnBansheeSpeed">
                 <Flags index="ShowInGlossary" value="1"/>
             </Button>
@@ -874,6 +1003,7 @@
         </InfoArray>
     </CAbilResearch>
     <CAbilTrain id="StarportTrain">
+        <InfoArray index="Train3" Time="42"/>
         <InfoArray index="Train7">
             <Button State="Available"/>
         </InfoArray>
@@ -912,9 +1042,12 @@
         </InfoArray>
     </CAbilMorph>
     <CAbilEffectTarget id="TimeWarp"/>
+    <CAbilTrain id="TrainQueen">
+        <InfoArray index="Train1" Effect=""/>
+    </CAbilTrain>
     <CAbilEffectTarget id="Transfusion">
         <Effect index="0" value="TransfusionImpactSet"/>
-        <CmdButtonArray index="Execute" Requirements="QueenOnCreep"/>
+        <CmdButtonArray index="Execute" Requirements="OnCreep"/>
     </CAbilEffectTarget>
     <CAbilResearch id="TwilightCouncilResearch">
         <InfoArray index="Research1">
@@ -998,6 +1131,10 @@
         <Arc value="360"/>
         <CmdButtonArray index="Execute" DefaultButtonFace="ParasiticBomb"/>
     </CAbilEffectTarget>
+    <CAbilEffectTarget id="VoidSwarmHostSpawnLocust">
+        <Flags index="RequireTargetVision" value="0"/>
+        <Flags index="Transient" value="1"/>
+    </CAbilEffectTarget>
     <CAbilWarpTrain id="WarpGateTrain">
         <InfoArray index="Train1" Time="16"/>
         <InfoArray index="Train2" Time="16"/>
@@ -1020,6 +1157,7 @@
     </CAbilEffectInstant>
     <CAbilEffectTarget id="WidowMineAttack">
         <PrepEffect value="WidowMineTargetingBeamDummy"/>
+        <AutoCastValidatorArray value="NotLarvaEgg"/>
     </CAbilEffectTarget>
     <CAbilEffectTarget id="LocustMPFlyingSwoopAttack">
         <Alignment value="Negative"/>
@@ -1095,9 +1233,11 @@
         <TargetFilters value="Biological,Visible;Self,Player,Ally,Structure,Destructible,Stasis,Dead,Hidden,Invulnerable"/>
         <Range value="10"/>
         <CmdButtonArray index="Execute" DefaultButtonFace="ChannelSnipe"/>
+        <CmdButtonArray index="Cancel" DefaultButtonFace="Cancel"/>
         <RangeSlop value="20"/>
         <UninterruptibleArray index="Cast" value="1"/>
         <UninterruptibleArray index="Channel" value="1"/>
+        <CancelableArray index="Channel" value="1"/>
     </CAbilEffectTarget>
     <CAbilMorph id="PurifyMorphPylon">
         <EditorCategories value="Race:Protoss,AbilityorEffectType:Units"/>
@@ -1162,6 +1302,29 @@
             </Button>
         </InfoArray>
     </CAbilResearch>
+    <CAbilMorph id="WidowMineBurrow">
+        <InfoArray index="0" RandomDelayMax="0.25">
+            <SectionArray index="Actor">
+                <DurationArray index="Duration" value="3.125"/>
+            </SectionArray>
+            <SectionArray index="Collide">
+                <DurationArray index="Delay" value="0.6806"/>
+            </SectionArray>
+            <!--SectionArray index="Mover">
+                <DurationArray index="Duration" value="3"/>
+            </SectionArray-->
+            <SectionArray index="Stats">
+                <DurationArray index="Delay" value="3.125"/>
+            </SectionArray>
+        </InfoArray>
+    </CAbilMorph>
+    <CAbilMorph id="WidowMineUnburrow">
+        <InfoArray index="0" RandomDelayMax="0.25">
+            <SectionArray index="Actor">
+                <DurationArray index="Duration" value="1.125"/>
+            </SectionArray>
+        </InfoArray>
+    </CAbilMorph>
     <CAbilEffectTarget id="Yamato">
         <Flags index="AbortOnAllianceChange" value="0"/>
         <Flags index="IgnoreOrderPlayerIdInStageValidate" value="1"/>
@@ -1175,6 +1338,9 @@
             <Cooldown TimeUse="100"/>
         </InterruptCost>
         <CancelEffect index="Prep" value="BattlecruiserYamatoCD"/>
+    </CAbilEffectTarget>
+    <CAbilEffectTarget id="Yoink">
+        <CastOutroTime value="1"/>
     </CAbilEffectTarget>
     <CAbilBuild id="ZergBuild">
         <InfoArray index="Build12" Unit="LurkerDenMP" Time="80">
@@ -1525,5 +1691,6 @@
     </CAbilResearch>
     <CAbilMove id="move">
         <AbilSetId value="Move"/>
+        <FollowAcquireRange value="2"/>
     </CAbilMove>
 </Catalog>

--- a/mods/voidmulti.sc2mod/base.sc2data/gamedata/actordata.xml
+++ b/mods/voidmulti.sc2mod/base.sc2data/gamedata/actordata.xml
@@ -13,6 +13,23 @@
     <CActorAction id="AdeptAttack">
         <ImpactModel value="AdeptAttackImpactModel"/>
     </CActorAction>
+    <CActorUnit id="Hydralisk">
+        <On index="65" Send="AnimBracketStart AttackSuperior Attack,Superior {} {} 0 1.245509 AsTimeScale"/>
+        <On index="66" Send="AnimBracketStart AttackInferior Attack,Inferior {} {} 0 1.245509 AsTimeScale"/>
+        <On index="67" Send="AnimPlay AttackCover Attack,Cover 0 -1.000000 -1.000000 1.500000 AsTimeScale"/>
+        <On index="68" Send="AnimBracketStart Attack Attack {} {} 0 1.245509 AsTimeScale"/>
+        <On index="73" Send="TimerSet 0.267000 MeleeAttackLaunch"/>
+        <On index="74" Send="TimerSet 0.066700 MeleeAttackLaunch"/>
+    </CActorUnit>
+    <CActorAction id="MutaliskAttackSegment2">
+        <LaunchAssets Sound=""/>
+    </CActorAction>
+    <CActorAction id="MutaliskAttackSegment3">
+        <LaunchAssets Sound=""/>
+    </CActorAction>
+    <CActorRange id="SensorTowerRadar">
+        <Range value="27.000000"/>
+    </CActorRange>
     <CActorAction id="TempestAttackGround">
         <ImpactModel value="TempestAttackGroundImpact"/>
         <!--ImpactModel value="TempestGroundAttackImpactModel"/-->
@@ -48,6 +65,7 @@
         <On Terms="SupporterDestruction" Send="AnimBracketStop BSD"/>
         <HostForProps Subject="ShieldBatteryRechargeEx5@Beam" Scope="Caster" Actor="Find"/>
         <ModelFlags index="AllowHitTest" value="0"/>
+        <FogVisibility value="Hidden"/>
     </CActorModel>
     <CActorList id="NexusShieldBatteryRangeIndicatorHelperList">
         <On Terms="ActorCreation" Send="ExternalFinderAdd"/>
@@ -74,7 +92,7 @@
         <On Terms="SelectionLocalUpdate.Nexus.Stop" Send="Destroy"/>
         <Icon value="Assets\Textures\RadarIcon2.dds"/>
         <IconArcLength value="1.750000"/>
-        <Range value="9.800000"/>
+        <Range value="10.000000"/>
     </CActorRange>
     <!--                                                                                         -->
     <!-- Nexus ................................................................................. -->
@@ -840,6 +858,9 @@
         <On Terms="Upgrade.AnabolicSynthesis.Remove; !ValidateUnit IsUltraliskBurrowed" Target="UltraliskAnabolicSynthesisUpgrade" Send="Destroy"/>
         <On Terms="AbilMorph.BurrowUltraliskUp.Finish; ValidatePlayer HasAnabolicSynthesisUpgrade" Send="Create UltraliskAnabolicSynthesisUpgrade"/>
         <On Terms="AbilMorph.BurrowUltraliskDown.Start" Target="UltraliskAnabolicSynthesisUpgrade" Send="Destroy"/>
+        <DeathActorModelLow value="UnitDeathModel"/>
+        <BarOffset value="16"/>
+        <BarWidth value="130"/>
     </CActorUnit>
     <CActorModel id="UltraliskAnabolicSynthesisUpgrade" parent="ModelAnimationStyleContinuous">
         <Inherits index="BaseModelScale" value="1"/>
@@ -1229,6 +1250,8 @@
     </CActorModel>
     <CActorUnit id="Zergling">
         <Macros value="PhysicsDeathsVoidGround"/>
+        <On index="71" Terms="AbilMorph.*.Finish; MorphTo Zergling; MorphFrom BanelingCocoon; !AbilKey BurrowUp"/>
+        <On index="72" Terms="AbilMorph.*.Finish; MorphFrom Zergling; MorphTo BanelingCocoon; !AbilKey BurrowDown"/>
         <!--On Terms="ActorCreation; PlayerHasReward ZerglingSkin" Send="StatusSet CE 1"/>
         <On Terms="StatusSet.*.CE; IsStatus CE 1" Send="ModelSwap ZerglingXPR"/>
         <On Terms="Upgrade.zerglingmovementspeed.Add; IsStatus CE 1" Send="ModelSwap ZerglingUpgradeXPR"/>
@@ -1483,6 +1506,7 @@
         <On Terms="AbilMorph.*.Start; MorphFrom ObserverSiegeMode; MorphTo Observer" Send="AnimBracketStop Work"/>
         <On Terms="UnitDetectedByViewer.*.On" Target="_UndetectedMuteSound" Send="SoundSetMuted"/>
         <On Terms="UnitDetectedByViewer.*.Off" Target="_UndetectedMuteSound" Send="SoundSetMuted 1"/>
+        <BarWidth value="46"/>
     </CActorUnit>
     <CActorModel id="ObserverObservationMode" parent="ModelAnimationStyleContinuous">
         <On Terms="ActorCreation" Send="Create Observer_SiegeMode_Loop_AS"/>
@@ -1837,7 +1861,7 @@
     </CActorSound>
     <CActorSimple id="RavenShredderMissileImpactArmorReductionTint">
         <On Terms="Behavior.RavenShredderMissileArmorReductionUISubtruct.On" Send="Create"/>
-        <On Terms="Behavior.RavenShredderMissileArmorReductionUISubtruct.On" Target="_Unit" Send="SetTintColor {255,100,0 2.000000} 0.100000 OneShot SeekerTargetArmor"/>
+        <On Terms="Behavior.RavenShredderMissileArmorReductionUISubtruct.On" Target="_Unit" Send="SetTintColor {255,187,85 2.000000} 0.100000 OneShot SeekerTargetArmor"/>
         <On Terms="Behavior.RavenShredderMissileArmorReductionUISubtruct.Off" Target="_Unit" Send="ClearTintColor 0.100000 SeekerTargetArmor"/>
         <On Terms="Behavior.RavenShredderMissileArmorReductionUISubtruct.Off" Send="Destroy"/>
     </CActorSimple>

--- a/mods/voidmulti.sc2mod/base.sc2data/gamedata/behaviordata.xml
+++ b/mods/voidmulti.sc2mod/base.sc2data/gamedata/behaviordata.xml
@@ -9,8 +9,14 @@
     <CBehaviorBuff id="AdeptPhaseShift">
         <Modification MoveSpeedBonus="0"/>
     </CBehaviorBuff>
+    <CBehaviorBuff id="AdeptPhaseShiftCaster">
+        <Modification>
+            <StateFlags index="SuppressPassenger" value="0"/>
+        </Modification>
+    </CBehaviorBuff>
     <CBehaviorBuff id="AdeptPhaseShiftTimer">
         <RemoveValidatorArray value="CasterIsNotRecallingNexus"/>
+        <RemoveValidatorArray value="CasterIsNotHidden"/>
     </CBehaviorBuff>
     <CBehaviorBuff id="BatteryEnergy">
         <InfoFlags index="Hidden" value="1"/>
@@ -18,10 +24,13 @@
         <Duration value="0.01"/>
         <ExpireEffect value="BatteryAddEnergy"/>
     </CBehaviorBuff>
+    <CBehaviorBuff id="BroodlingFate">
+        <Duration value="5"/>
+    </CBehaviorBuff>
     <CBehaviorBuff id="DarkTemplarBlinkAttackDelay">
         <InfoFlags index="Hidden" value="1"/>
         <EditorCategories value="Race:Protoss,AbilityorEffectType:Units"/>
-        <Duration value="1.05"/>
+        <Duration value="1"/>
         <Modification>
             <StateFlags index="SuppressAttack" value="1"/>
             <AbilCategoriesEnable index="Passive" value="1"/>
@@ -33,7 +42,16 @@
         <Start value="Footprint4x4CreepSourceGrown"/>
         <Birth value="CreepGrowthMediumNydusCreepSourceStart"/>
         <Grown value="Footprint4x4CreepSourceGrown"/>
+        <InfoFlags index="Hidden" value="1"/>
     </CBehaviorCreepSource>
+    <CBehaviorBuff id="OracleStasisTrapTarget">
+        <Modification>
+            <ModifyFlags index="DisableAbils" value="0"/>
+            <ModifyFlags index="SuppressMoving" value="0"/>
+            <ModifyFlags index="SuppressTurning" value="0"/>
+            <AbilClassDisableArray index="CAbilBuild" value="1"/>
+        </Modification>
+    </CBehaviorBuff>
     <CBehaviorBuff id="QueenMustBeOnCreep">
         <InfoFlags index="Hidden" value="1"/>
         <EditorCategories value="Race:Zerg,AbilityorEffectType:Units"/>
@@ -189,9 +207,9 @@
         <EditorCategories value="AbilityorEffectType:Units,Race:Terran"/>
         <RemoveValidatorArray value="NotOracleStasisTrapped"/>
         <Duration value="30"/>
-        <Modification ShieldArmorBonus="3">
+        <Modification ShieldArmorBonus="2">
             <ModifyFlags index="HideChangeUI" value="1"/>
-            <LifeArmorBonus value="3"/>
+            <LifeArmorBonus value="2"/>
         </Modification>
         <InfoFlags index="Hidden" value="1"/>
     </CBehaviorBuff>
@@ -201,8 +219,8 @@
         <EditorCategories value="AbilityorEffectType:Units,Race:Terran"/>
         <RemoveValidatorArray value="NotOracleStasisTrapped"/>
         <Duration value="30"/>
-        <Modification ShieldArmorBonus="-3">
-            <LifeArmorBonus value="-3"/>
+        <Modification ShieldArmorBonus="-2">
+            <LifeArmorBonus value="-2"/>
         </Modification>
         <DisplayDuration index="Self" value="1"/>
         <DisplayDuration index="Ally" value="1"/>
@@ -214,6 +232,9 @@
         <Capacity value="2250"/>
         <Contents value="2250"/>
     </CBehaviorResource>
+    <CBehaviorBuff id="SensorTowerRadar">
+        <Modification Radar="27"/>
+    </CBehaviorBuff>
     <CBehaviorBuff id="TemporalField">
         <Modification AttackSpeedMultiplier="0.5"/>
     </CBehaviorBuff>
@@ -539,7 +560,7 @@
         <Period value="0.63"/>
     </CBehaviorCreepSource>
     <CBehaviorCreepSource id="makeCreep8x6">
-        <Period value="0.42"/>
+        <Period value="0.35"/>
     </CBehaviorCreepSource>
     <CBehaviorBuff id="BarrierDamageResponse">
         <InfoFlags index="Hidden" value="1"/>
@@ -676,13 +697,16 @@
         <Alignment value="Negative"/>
         <InfoIcon value="Assets\Textures\btn-upgrade-terran-interferencematrix.dds"/>
         <EditorCategories value="AbilityorEffectType:Units"/>
-        <Duration value="15"/>
+        <Duration value="11"/>
         <ExpireEffect value="ImmortalBarrierCDFix"/>
         <Modification>
             <ModifyFlags index="DisableAbils" value="1"/>
+            <ModifyFlags index="EnableAttack" value="1"/>
             <ModifyFlags index="EnableMove" value="1"/>
             <StateFlags index="SuppressAttack" value="1"/>
             <StateFlags index="SuppressCloak" value="1"/>
+            <StateFlags index="SuppressCombat" value="1"/>
+            <AbilClassEnableArray index="CAbilStop" value="1"/>
             <BehaviorLinkDisableArray value="ImmortalBarrierSupressed"/>
         </Modification>
         <DisplayDuration index="Self" value="1"/>
@@ -710,6 +734,9 @@
         <EditorCategories value="AbilityorEffectType:Units"/>
         <Duration value="0.2"/>
         <AINotifyEffect value="SeekerMissileDamage"/>
+        <DamageResponse>
+            <ModifyAmount value="2"/>
+        </DamageResponse>
     </CBehaviorBuff>
     <CBehaviorBuff id="RavenShredderMissileArmorReduction">
         <Alignment value="Negative"/>
@@ -725,7 +752,7 @@
             <Kind index="Spell" value="0"/>
             <Kind index="Splash" value="0"/>
             <Kind index="NoProc" value="0"/>
-            <ModifyAmount value="3"/>
+            <ModifyAmount value="2"/>
             <Chance value="1"/>
         </DamageResponse>
     </CBehaviorBuff>
@@ -863,6 +890,14 @@
             <WeaponArray Link="MothershipCoreWeapon"/>
             <WeaponArray Link="MothershipCoreWeapon" Turret="Nexus"/>
         </Modification-->
+    </CBehaviorBuff>
+    <CBehaviorBuff id="BatteryAcquireTargetCooldown">
+        <InfoFlags index="Hidden" value="1"/>
+        <EditorCategories value="AbilityorEffectType:Units"/>
+        <MaxStackCount value="65535"/>
+        <MaxStackCountPerCaster value="1"/>
+        <TimeScaleSource Value="Caster"/>
+        <Duration value="0.063"/>
     </CBehaviorBuff>
     <CBehaviorBuff id="BatteryOvercharge">
         <Alignment value="Positive"/>

--- a/mods/voidmulti.sc2mod/base.sc2data/gamedata/buttondata.xml
+++ b/mods/voidmulti.sc2mod/base.sc2data/gamedata/buttondata.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Catalog>
+    <CButton id="Baneling2">
+        <Icon value="Assets\Textures\btn-unit-zerg-baneling.dds"/>
+        <AlertIcon value="Assets\Textures\btn-unit-zerg-baneling.dds"/>
+        <EditorCategories value="Race:Zerg"/>
+    </CButton>
     <CButton id="BurrowDown">
         <HotkeySet value="BurrowUnburrowModes"/>
     </CButton>

--- a/mods/voidmulti.sc2mod/base.sc2data/gamedata/effectdata.xml
+++ b/mods/voidmulti.sc2mod/base.sc2data/gamedata/effectdata.xml
@@ -24,6 +24,10 @@
         <ExpireDelay value="0.0625"/>
         <FinalEffect value="IssueOrderMorphtoWarpGate"/>
     </CEffectCreatePersistent>
+    <CEffectCreatePersistent id="BacklashRockets">
+        <PeriodicPeriodArray index="0" value="0"/>
+        <PeriodicPeriodArray value="0.15"/>
+    </CEffectCreatePersistent>
     <CEffectModifyUnit id="BatteryAddEnergy">
         <ValidatorArray value="NexusBatteryOvercharge8RangePlacementVisual"/>
         <EditorCategories value=""/>
@@ -194,6 +198,9 @@
         <InitialEffect value="SentryWeaponPeriodicSet"/>
         <PeriodicPeriodArray index="0" value="0.0625"/>
     </CEffectCreatePersistent>
+    <CEffectEnumArea id="EMPSearch">
+        <AreaArray index="0" Radius="1.75"/>
+    </CEffectEnumArea>
     <CEffectCreatePersistent id="HyperjumpInitialCP">
         <ValidatorArray value="CasterNotFungalGrowthed"/>
         <ValidatorArray value="CasterIsNotYoinked"/>
@@ -292,6 +299,9 @@
     <CEffectDestroyPersistent id="PhaseDestroyGravitonBeamPersistant">
         <Radius value="0"/>
     </CEffectDestroyPersistent>
+    <CEffectEnumArea id="PurificationNovaTargettedSearch">
+        <AreaArray index="0" Radius="1.35"/>
+    </CEffectEnumArea>
     <CEffectSet id="RavenScramblerDummy">
         <EditorCategories value="Race:Terran"/>
     </CEffectSet>
@@ -542,6 +552,9 @@
     <CEffectCreateUnit id="ReaperKD8Knockback">
         <ValidatorArray value="IsNotRecallingNexus"/>
     </CEffectCreateUnit>
+    <CEffectCreateHealer id="ShieldBatteryRechargeChanneledOvercharged">
+        <RechargeVitalRate value="54"/>
+    </CEffectCreateHealer>
     <CEffectCreateHealer id="ShieldBatteryRechargeEx5">
         <ValidatorArray value="noMarkers"/>
         <ValidatorArray value="NotVortexd"/>
@@ -556,6 +569,7 @@
         </DrainVitalCostFactor>
         <RechargeVital value="Shields"/>
         <RechargeVitalRate value="36"/>
+        <InitialEffect value="BatteryCooldownAB"/>
     </CEffectCreateHealer>
     <CEffectDamage id="ShieldBatteryRechargeEx5@DamageDummy">
         <EditorCategories value="Race:Protoss"/>
@@ -709,8 +723,6 @@
         <AttributeBonus index="Light" value="0"/>
     </CEffectDamage>
     <CEffectCreatePersistent id="LurkerMP">
-        <Flags index="Channeled" value="0"/>
-        <Flags index="EffectFailure" value="0"/>
         <PeriodicPeriodArray value="0.125"/>
         <PeriodicPeriodArray value="0.125"/>
         <PeriodicPeriodArray value="0.125"/>
@@ -724,6 +736,7 @@
         <PeriodicOffsetArray value="0,-11,0"/>
         <PeriodicOffsetArray value="0,-12,0"/>
         <PeriodicEffectArray index="0" value="LurkerMPCU"/>
+        <PeriodicValidator value=""/>
     </CEffectCreatePersistent>
     <CEffectDamage id="LurkerMPDamage">
         <Kind value="Ranged"/>
@@ -731,7 +744,7 @@
     </CEffectDamage>
     <CEffectEnumArea id="LurkerMPSearch">
         <AreaArray index="0" Radius="0.5"/>
-        <ValidatorArray value="WeaponInRange"/>
+        <ValidatorArray index="0" value="WeaponInRange"/>
     </CEffectEnumArea>
     <CEffectCreateHealer id="MedivacHeal">
         <ValidatorArray index="7" value=""/>
@@ -1826,7 +1839,7 @@
     </CEffectModifyUnit>
     <CEffectModifyUnit id="ImmortalBarrierCDFix">
         <ValidatorArray value="BarrierOnCooldown"/>
-        <Cost Behavior="ImmortalBarrierSupressed" CooldownOperation="Add" CooldownTimeUse="8"/>
+        <Cost Behavior="ImmortalBarrierSupressed" CooldownOperation="Add" CooldownTimeUse="11"/>
     </CEffectModifyUnit>
     <CEffectApplyBehavior id="NexusShieldRechargeOnPylonAB">
         <ValidatorArray index="0" value="IsPylon"/>
@@ -1933,8 +1946,7 @@
         <ValidatorArray value="SourceNotHidden"/>
         <ValidatorArray value="NotInterceptor"/>
     </CEffectSet>
-    <CEffectCreateHealer id="ShieldBatteryRechargeChanneledOvercharged">
-        <!--ValidatorArray value="noMarkers"/>
+    <!--ValidatorArray value="noMarkers"/>
         <ValidatorArray value="ShieldsNotFull"/>
         <ValidatorArray value="NotWarpingIn"/>
         <ValidatorArray value="HiddenCompareAB"/>
@@ -1942,16 +1954,6 @@
         <ValidatorArray value="NotVortexd"/>
         <ValidatorArray value="SourceNotHidden"/>
         <ValidatorArray value="NotInterceptor"/-->
-        <ValidatorArray value="CasterHasBatteryOverchargeBehavior"/>
-        <ValidatorArray value="NotHidden"/>
-        <ValidatorArray value="NotVortexd"/>
-        <EditorCategories value="Race:Terran"/>
-        <PeriodicValidator value="ShieldsNotFull"/>
-        <DrainVital value="Energy"/>
-        <RechargeVital value="Shields"/>
-        <RechargeVitalRate value="72"/>
-        <PeriodicEffect value="ShieldBatteryRechargeChanneledRevealSearch"/>
-    </CEffectCreateHealer>
     <CEffectCreateHealer id="ShieldBatteryRechargeChanneled">
         <!--ValidatorArray value="noMarkers"/>
         <ValidatorArray value="ShieldsNotFull"/>
@@ -2157,6 +2159,13 @@
         <Amount value="5"/>
         <Kind value="Ranged"/>
     </CEffectDamage>
+    <CEffectApplyBehavior id="BatteryCooldownAB">
+        <EditorCategories value=""/>
+        <WhichUnit Value="Source"/>
+        <Behavior value="BatteryAcquireTargetCooldown"/>
+        <Flags index="UseDuration" value="1"/>
+        <Duration value="0.063"/>
+    </CEffectApplyBehavior>
     <CEffectApplyBehavior id="BattlecrusierDisableWeaponsAB">
         <EditorCategories value="Race:Protoss"/>
         <WhichUnit Value="Caster"/>

--- a/mods/voidmulti.sc2mod/base.sc2data/gamedata/modeldata.xml
+++ b/mods/voidmulti.sc2mod/base.sc2data/gamedata/modeldata.xml
@@ -352,6 +352,34 @@
             <Payload value="Repair_Bot_Beam_01"/>
         </Events>
     </CModel>
+    <CModel id="Observer">
+        <Radius value="0.438000"/>
+        <ScaleMax value="1.000000,1.000000,1.000000"/>
+        <ScaleMin value="1.000000,1.000000,1.000000"/>
+        <SelectionRadius value="0.515000"/>
+        <ShadowRadius value="0.515000"/>
+    </CModel>
+    <CModel id="ObserverPlacement">
+        <Radius value="0.438000"/>
+        <ScaleMax value="1.000000,1.000000,1.000000"/>
+        <ScaleMin value="1.000000,1.000000,1.000000"/>
+        <SelectionRadius value="0.515000"/>
+        <ShadowRadius value="0.515000"/>
+    </CModel>
+    <CModel id="PurificationNova">
+        <Radius value="2.291700"/>
+        <RadiusLoose value="2.291700"/>
+        <ScaleMax value="0.640000,0.640000,0.640000"/>
+        <ScaleMin value="0.640000,0.640000,0.640000"/>
+    </CModel>
+    <CModel id="PurificationNovaRangeIndicator">
+        <Radius value="2.291700"/>
+        <RadiusLoose value="2.291700"/>
+        <!--ScaleMax value="1.200000,1.200000,1.200000"/>
+        <ScaleMin value="1.200000,1.200000,1.200000"\-->
+        <ScaleMax value="0.687500,0.687500,0.687500"/>
+        <ScaleMin value="0.687500,0.687500,0.687500"/>
+    </CModel>
     <CModel id="ShieldBatteryRechargeEx5@Beam" parent="PersistentSpellFX">
         <Model value="Assets\Effects\Protoss\ProtossShield_Battery_Beam\ProtossShield_Battery_Beam.m3"/>
         <EditorCategories value="Race:Protoss"/>
@@ -851,6 +879,10 @@
     </CModel>
     <CModel id="TemporalFieldImpactModel">
         <Model value="Assets\Effects\Protoss\TimeWarpImpact_Red\TimeWarpImpact_Red.m3"/>
+    </CModel>
+    <CModel id="Ultralisk">
+        <ScaleMax value="0.750000,0.750000,0.750000"/>
+        <ScaleMin value="0.750000,0.750000,0.750000"/>
     </CModel>
     <CModel id="UrsadakMale" parent="Unit">
         <Model value="Assets\Units\Critters\UrsadakMale\UrsadakMale.m3"/>

--- a/mods/voidmulti.sc2mod/base.sc2data/gamedata/requirementdata.xml
+++ b/mods/voidmulti.sc2mod/base.sc2data/gamedata/requirementdata.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Catalog>
     <CRequirement id="HaveAdeptPiercingAttack"/>
+    <CRequirement id="HaveBanelingNest3">
+        <EditorCategories value="Race:Zerg,TechType:Unit"/>
+        <CanBeSuppressed index="Use" value="0"/>
+        <NodeArray index="Use" Link="CountUnitBanelingNestCompleteOnlyTechTreeCheat"/>
+    </CRequirement>
     <CRequirement id="HaveTempestGroundAttackUpgrade">
         <NodeArray index="Use" Link="CountUpgradeTempestGroundAttackUpgradeCompleteOnly788113278"/>
     </CRequirement>

--- a/mods/voidmulti.sc2mod/base.sc2data/gamedata/sounddata.xml
+++ b/mods/voidmulti.sc2mod/base.sc2data/gamedata/sounddata.xml
@@ -270,6 +270,12 @@
         <VolumeRolloffPoints Distance="10.000000"/>
         <VolumeRolloffPoints Distance="20.000000" Volume="-96.000000"/>
     </CSound>
+    <CSound id="Interceptor_AttackImpact">
+        <Volume value="-9.000000,-8.000000"/>
+    </CSound>
+    <CSound id="Interceptor_AttackLaunch">
+        <Volume value="-8.000000,-5.000000"/>
+    </CSound>
     <CSound id="XelNagaObeliskConstructDoodadWorkA" parent="Ambience_Object">
         <EditorCategories value="Race:Neutral"/>
         <AssetArray File="Assets\Sounds\Zerus01_Volcanic_Rumble_1.ogg" FacialGroup=""/>
@@ -1918,18 +1924,8 @@
     </CSound>
     <CSound id="HologramProjectorLoop">
         <Volume value="-12.000000,-12.000000"/>
-        <AssetArray index="0">
-            <File value="Assets\Sounds\AmbEmitter_VoxJibberishFutz01.wav"/>
-            <Pitch value="-8.000000,-8.000000"/>
-            <Volume value="-10.000000,-10.000000"/>
-            <FacialGroup value=""/>
-        </AssetArray>
-        <AssetArray index="1">
-            <File value="Assets\Sounds\AmbEmitter_VoxJibberishFutz02.wav"/>
-            <Pitch value="-8.000000,-8.000000"/>
-            <Volume value="-10.000000,-10.000000"/>
-            <FacialGroup value=""/>
-        </AssetArray>
+        <AssetArray index="0" File="Assets\Sounds\AmbEmitter_VoxJibberishFutz01.wav" Pitch="-8.000000,-8.000000" Volume="-10.000000,-10.000000"/>
+        <AssetArray index="1" File="Assets\Sounds\AmbEmitter_VoxJibberishFutz02.wav" Pitch="-8.000000,-8.000000" Volume="-10.000000,-10.000000"/>
         <AssetArray>
             <File value="Assets\Sounds\AmbEmitter_VoxJibberishFutz03.wav"/>
             <Pitch value="-8.000000,-8.000000"/>
@@ -1947,8 +1943,8 @@
     </CSound>
     <CSound id="HologramProjector_PowerOff">
         <Volume value="-20.000000,-20.000000"/>
-        <AssetArray index="0" File="Assets\Sounds\HologramProjectorOff1.wav" Volume="-6.000000,-6.000000" FacialGroup=""/>
-        <AssetArray index="1" File="Assets\Sounds\HologramProjectorOff2.wav" Volume="-6.000000,-6.000000" FacialGroup=""/>
+        <AssetArray index="0" Volume="-6.000000,-6.000000"/>
+        <AssetArray index="1" Volume="-6.000000,-6.000000"/>
         <AssetArray>
             <File value="Assets\Sounds\UI_Void_On_Off_2.wav"/>
             <Pitch value="-12.000000,-12.000000"/>
@@ -1963,7 +1959,7 @@
         </AssetArray>
     </CSound>
     <CSound id="HologramProjector_PowerOn">
-        <AssetArray index="0" File="Assets\Sounds\HologramProjectorOn1.wav" Volume="-3.000000,-3.000000" FacialGroup=""/>
+        <AssetArray index="0" Volume="-3.000000,-3.000000"/>
         <AssetArray>
             <File value="Assets\Sounds\UI_Void_On_Off_3.wav"/>
             <Pitch value="-12.000000,-12.000000"/>

--- a/mods/voidmulti.sc2mod/base.sc2data/gamedata/unitdata.xml
+++ b/mods/voidmulti.sc2mod/base.sc2data/gamedata/unitdata.xml
@@ -9,6 +9,8 @@
         <GlossaryWeakArray index="1" value="Roach"/>
         <GlossaryWeakArray index="2" value="Stalker"/>
         <CardLayouts index="0">
+            <LayoutButtons index="6" Face="Cancel" AbilCmd="AdeptPhaseShiftCancel,Execute"/>
+            <LayoutButtons index="7" Face="Rally" AbilCmd="ProgressRally,Rally1"/>
             <LayoutButtons Face="AdeptPiercingUpgrade" Type="Passive" Requirements="HaveAdeptPiercingAttack" Row="2" Column="1"/>
         </CardLayouts>
         <ShieldsStart value="70"/>
@@ -30,6 +32,7 @@
         <GlossaryStrongArray value="Mutalisk"/>
         <GlossaryStrongArray value="Adept"/>
         <GlossaryWeakArray index="1" value="Hydralisk"/>
+        <InnerRadius value="0.5625"/>
     </CUnit>
     <CUnit id="Assimilator">
         <Collide index="Locust" value="1"/>
@@ -55,10 +58,167 @@
         <GlossaryWeakArray value="Hydralisk"/>
         <GlossaryWeakArray value="Immortal"/>
     </CUnit>
+    <CUnit id="Baneling2">
+        <DeathRevealRadius value="3"/>
+        <Facing value="45"/>
+        <Race value="Zerg"/>
+        <Mob value="Multiplayer"/>
+        <FlagArray index="PreventDestroy" value="1"/>
+        <FlagArray index="UseLineOfSight" value="1"/>
+        <FlagArray index="AISplash" value="1"/>
+        <FlagArray index="AIHighPrioTarget" value="1"/>
+        <FlagArray index="AIFleeDamageDisabled" value="1"/>
+        <FlagArray index="ArmySelect" value="1"/>
+        <PlaneArray index="Ground" value="1"/>
+        <Collide index="Ground" value="1"/>
+        <Collide index="ForceField" value="1"/>
+        <Collide index="Locust" value="1"/>
+        <Collide index="Small" value="1"/>
+        <Attributes index="Biological" value="1"/>
+        <LifeStart value="30"/>
+        <LifeMax value="30"/>
+        <LifeRegenRate value="0.2734"/>
+        <LifeArmorName value="Unit/LifeArmorName/ZergGroundArmor"/>
+        <Speed value="2.5"/>
+        <SpeedMultiplierCreep value="1.3"/>
+        <Acceleration value="1000"/>
+        <LateralAcceleration value="46.0625"/>
+        <StationaryTurningRate value="999.8437"/>
+        <TurningRate value="999.8437"/>
+        <Sight value="8"/>
+        <Food value="-0.5"/>
+        <CostCategory value="Army"/>
+        <CostResource index="Minerals" value="50"/>
+        <CostResource index="Vespene" value="25"/>
+        <AttackTargetPriority value="20"/>
+        <DamageDealtXP value="1"/>
+        <DamageTakenXP value="1"/>
+        <KillXP value="30"/>
+        <AbilArray Link="stop"/>
+        <AbilArray Link="attack"/>
+        <AbilArray Link="move"/>
+        <AbilArray Link="BurrowBanelingDown"/>
+        <AbilArray Link="SapStructure"/>
+        <AbilArray Link="Explode"/>
+        <AbilArray Link="VolatileBurstBuilding"/>
+        <BehaviorArray Link="BanelingExplode"/>
+        <BehaviorArray/>
+        <WeaponArray Link="VolatileBurst"/>
+        <WeaponArray Link="VolatileBurstBuilding"/>
+        <CardLayouts>
+            <LayoutButtons Face="Move" Type="AbilCmd" AbilCmd="move,Move" Row="0" Column="0"/>
+            <LayoutButtons Face="Stop" Type="AbilCmd" AbilCmd="stop,Stop" Row="0" Column="1"/>
+            <LayoutButtons Face="MoveHoldPosition" Type="AbilCmd" AbilCmd="move,HoldPos" Row="0" Column="2"/>
+            <LayoutButtons Face="Attack" Type="AbilCmd" AbilCmd="attack,Execute" Row="0" Column="4"/>
+            <LayoutButtons Face="MovePatrol" Type="AbilCmd" AbilCmd="move,Patrol" Row="0" Column="3"/>
+            <LayoutButtons Row="0" Column="0"/>
+            <LayoutButtons Face="Explode" Type="AbilCmd" AbilCmd="Explode,Execute" Row="2" Column="0"/>
+            <LayoutButtons Face="BurrowDown" Type="AbilCmd" AbilCmd="BurrowBanelingDown,Execute" Row="2" Column="3"/>
+            <LayoutButtons Face="EnableBuildingAttack" Type="AbilCmd" AbilCmd="VolatileBurstBuilding,On" Row="2" Column="1"/>
+            <LayoutButtons Face="DisableBuildingAttack" Type="AbilCmd" AbilCmd="VolatileBurstBuilding,Off" Row="2" Column="2"/>
+            <LayoutButtons Face="BurrowDown" Type="AbilCmd" AbilCmd="BurrowDroneDown,Execute" Row="2" Column="3"/>
+            <LayoutButtons Face="BurrowDown" Type="AbilCmd" AbilCmd="BurrowZerglingDown,Execute" Row="2" Column="3"/>
+            <LayoutButtons Face="BurrowDown" Type="AbilCmd" AbilCmd="BurrowBanelingDown,Execute" Row="2" Column="3"/>
+            <LayoutButtons Face="BurrowDown" Type="AbilCmd" AbilCmd="BurrowRoachDown,Execute" Row="2" Column="3"/>
+            <LayoutButtons Face="BurrowDown" Type="AbilCmd" AbilCmd="BurrowHydraliskDown,Execute" Row="2" Column="3"/>
+            <LayoutButtons Face="BurrowDown" Type="AbilCmd" AbilCmd="BurrowRavagerDown,Execute" Row="2" Column="3"/>
+            <LayoutButtons Face="BurrowDown" Type="AbilCmd" AbilCmd="MorphToSwarmHostBurrowedMP,Execute" Row="2" Column="3"/>
+            <LayoutButtons Face="BurrowDown" Type="AbilCmd" AbilCmd="BurrowQueenDown,Execute" Row="2" Column="3"/>
+            <LayoutButtons Face="BurrowDown" Type="AbilCmd" AbilCmd="BurrowInfestorTerranDown,Execute" Row="2" Column="3"/>
+            <LayoutButtons Face="BurrowDown" Type="AbilCmd" AbilCmd="BurrowInfestorDown,Execute" Row="2" Column="3"/>
+            <LayoutButtons Face="BurrowDown" Type="AbilCmd" AbilCmd="BurrowUltraliskDown,Execute" Row="2" Column="3"/>
+            <LayoutButtons Face="BurrowUp" Type="AbilCmd" AbilCmd="BurrowDroneUp,Execute" Row="2" Column="4"/>
+            <LayoutButtons Face="BurrowUp" Type="AbilCmd" AbilCmd="BurrowZerglingUp,Execute" Row="2" Column="4"/>
+            <LayoutButtons Face="BurrowUp" Type="AbilCmd" AbilCmd="BurrowBanelingUp,Execute" Row="2" Column="4"/>
+            <LayoutButtons Face="BurrowUp" Type="AbilCmd" AbilCmd="BurrowRoachUp,Execute" Row="2" Column="4"/>
+            <LayoutButtons Face="BurrowUp" Type="AbilCmd" AbilCmd="BurrowHydraliskUp,Execute" Row="2" Column="4"/>
+            <LayoutButtons Face="BurrowUp" Type="AbilCmd" AbilCmd="BurrowRavagerUp,Execute" Row="2" Column="4"/>
+            <LayoutButtons Face="BurrowUp" Type="AbilCmd" AbilCmd="MorphToSwarmHostMP,Execute" Row="2" Column="4"/>
+            <LayoutButtons Face="BurrowUp" Type="AbilCmd" AbilCmd="BurrowQueenUp,Execute" Row="2" Column="4"/>
+            <LayoutButtons Face="BurrowUp" Type="AbilCmd" AbilCmd="BurrowInfestorTerranUp,Execute" Row="2" Column="4"/>
+            <LayoutButtons Face="BurrowUp" Type="AbilCmd" AbilCmd="BurrowInfestorUp,Execute" Row="2" Column="4"/>
+            <LayoutButtons Face="BurrowUp" Type="AbilCmd" AbilCmd="BurrowUltraliskUp,Execute" Row="2" Column="4"/>
+        </CardLayouts>
+        <Radius value="0.375"/>
+        <SeparationRadius value="0.375"/>
+        <InnerRadius value="0.375"/>
+        <CargoOverlapFilters value="-;Player,Ally,Neutral,Structure"/>
+        <CargoSize value="2"/>
+        <ScoreMake value="50"/>
+        <ScoreKill value="75"/>
+        <ScoreResult value="BuildOrder"/>
+        <SubgroupPriority value="82"/>
+        <MinimapRadius value="0.375"/>
+        <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
+        <TacticalAI value="Baneling"/>
+        <TacticalAIThink value="AIThinkBaneling"/>
+        <AIEvalFactor value="3"/>
+        <EquipmentArray Weapon="VolatileBurstDummy"/>
+        <GlossaryCategory value="Unit/Category/ZergUnits"/>
+        <GlossaryPriority value="60"/>
+        <GlossaryStrongArray value="Marine"/>
+        <GlossaryStrongArray value="Zergling"/>
+        <GlossaryStrongArray value="Zealot"/>
+        <GlossaryWeakArray value="Marauder"/>
+        <GlossaryWeakArray value="Infestor"/>
+        <GlossaryWeakArray value="Stalker"/>
+        <HotkeyCategory value="Unit/Category/ZergUnits"/>
+        <KillDisplay value="Always"/>
+        <RankDisplay value="Always"/>
+    </CUnit>
     <CUnit id="BanelingCocoon">
         <Collide index="Locust" value="1"/>
         <SubgroupPriority value="54"/>
         <FlagArray index="ArmySelect" value="1"/>
+        <AbilArray index="0" Link="Rally"/>
+        <AbilArray index="1" Link="MorphToBaneling"/>
+        <CardLayouts index="0">
+            <LayoutButtons index="0" AbilCmd="MorphToBaneling,Cancel"/>
+        </CardLayouts>
+    </CUnit>
+    <CUnit id="BanelingCocoon2">
+        <DeathRevealRadius value="3"/>
+        <Race value="Zerg"/>
+        <FlagArray index="PreventDestroy" value="1"/>
+        <FlagArray index="UseLineOfSight" value="1"/>
+        <FlagArray index="NoScore" value="1"/>
+        <FlagArray index="ArmySelect" value="1"/>
+        <PlaneArray index="Ground" value="1"/>
+        <Collide index="Ground" value="1"/>
+        <Collide index="ForceField" value="1"/>
+        <Collide index="Locust" value="1"/>
+        <Collide index="Small" value="1"/>
+        <Attributes index="Biological" value="1"/>
+        <LifeStart value="50"/>
+        <LifeMax value="50"/>
+        <LifeArmor value="2"/>
+        <LifeRegenRate value="0.2734"/>
+        <LifeArmorName value="Unit/LifeArmorName/ZergGroundArmor"/>
+        <Speed value="2.5"/>
+        <StationaryTurningRate value="719.4726"/>
+        <TurningRate value="719.4726"/>
+        <Sight value="5"/>
+        <Food value="-0.5"/>
+        <CostResource index="Minerals" value="50"/>
+        <CostResource index="Vespene" value="25"/>
+        <AttackTargetPriority value="10"/>
+        <DamageDealtXP value="1"/>
+        <DamageTakenXP value="1"/>
+        <KillXP value="25"/>
+        <AbilArray Link="que1"/>
+        <AbilArray Link="Rally"/>
+        <CardLayouts>
+            <LayoutButtons Face="CancelCocoonMorph" Type="AbilCmd" AbilCmd="que1,CancelLast" Row="2" Column="4"/>
+            <LayoutButtons Face="Rally" Type="AbilCmd" AbilCmd="Rally,Rally1" Row="2" Column="4"/>
+            <LayoutButtons Face="Attack" Type="AbilCmd" AbilCmd="attack,Execute" Row="0" Column="4"/>
+        </CardLayouts>
+        <Radius value="0.375"/>
+        <SeparationRadius value="0.375"/>
+        <InnerRadius value="0.375"/>
+        <ScoreKill value="75"/>
+        <SubgroupPriority value="54"/>
+        <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
+        <TacticalAI value="BanelingEgg"/>
     </CUnit>
     <CUnit id="BanelingNest">
         <Collide index="Locust" value="1"/>
@@ -116,6 +276,7 @@
         <GlossaryStrongArray index="1" value="Ultralisk"/>
         <GlossaryStrongArray index="2" value="HighTemplar"/>
         <GlossaryWeakArray index="2" value="Tempest"/>
+        <Speed value="1.6406"/>
     </CUnit>
     <CUnit id="BroodLordCocoon">
         <FlagArray index="ArmySelect" value="1"/>
@@ -224,6 +385,7 @@
         <CardLayouts index="0" removed="1"/>
         <Attributes index="Light" value="1"/>
         <Attributes index="Armored" value="0"/>
+        <Sight value="10"/>
     </CUnit>
     <CUnit id="CreepTumorBurrowed">
         <CardLayouts index="0">
@@ -232,10 +394,12 @@
         </CardLayouts>
         <Attributes index="Light" value="1"/>
         <Attributes index="Armored" value="0"/>
+        <Sight value="10"/>
     </CUnit>
     <CUnit id="CreepTumorQueen">
         <Attributes index="Light" value="1"/>
         <Attributes index="Armored" value="0"/>
+        <Sight value="10"/>
     </CUnit>
     <CUnit id="DarkShrine">
         <Collide index="Locust" value="1"/>
@@ -519,7 +683,7 @@
             <LayoutButtons index="9" Face="CloakOff" AbilCmd="GhostCloak,Off" Column="3"/>
             <LayoutButtons index="10" Face="EMP" AbilCmd="EMP,Execute" Column="1"/>
             <LayoutButtons index="11" Face="WeaponsFree" AbilCmd="GhostWeaponsFree,Execute" Row="1" Column="3"/>
-            <LayoutButtons index="12" Face="Cancel" AbilCmd="BypassArmorCancel,255" Row="2" Column="4"/>
+            <LayoutButtons index="12" Face="Cancel" AbilCmd="ChannelSnipe,Cancel" Row="2" Column="4"/>
             <LayoutButtons Face="ChannelSnipe" Type="AbilCmd" AbilCmd="ChannelSnipe,Execute" Row="2" Column="0"/>
             <LayoutButtons Face="EnhancedShockwaves" Type="Passive" Requirements="UseEnhancedShockwaves" Row="1" Column="1"/>
         </CardLayouts>
@@ -537,11 +701,17 @@
         <GlossaryCategory value=""/>
         <GlossaryWeakArray index="0" value="Marauder"/>
         <GlossaryWeakArray index="1" value="Zergling"/>
+        <CardLayouts index="0">
+            <LayoutButtons index="12" Face="Cancel" AbilCmd="BypassArmorCancel,255" Row="2" Column="4"/>
+        </CardLayouts>
     </CUnit>
     <CUnit id="GhostNova" parent="Ghost">
         <GlossaryCategory value=""/>
         <GlossaryWeakArray index="0" value="Marauder"/>
         <GlossaryWeakArray index="1" value="Zergling"/>
+        <CardLayouts index="0">
+            <LayoutButtons index="12" Face="Cancel" AbilCmd="BypassArmorCancel,255" Row="2" Column="4"/>
+        </CardLayouts>
     </CUnit>
     <CUnit id="GhostAcademy">
         <CardLayouts index="0">
@@ -551,7 +721,7 @@
             <LayoutButtons index="3" Face="NukeArm" AbilCmd="ArmSiloWithNuke,Ammo1" Column="0"/>
             <LayoutButtons index="4" Face="SelectBuilder" Type="SelectBuilder" AbilCmd="" Row="1" Column="3"/>
             <LayoutButtons index="5" Face="ResearchPersonalCloaking" AbilCmd="GhostAcademyResearch,Research1" Column="0"/>
-            <LayoutButtons index="6" Face="ResearchEnhancedShockwaves" Type="AbilCmd" AbilCmd="GhostAcademyResearch,Research3" Row="0" Column="1"/>
+            <LayoutButtons index="6" removed="1"/>
         </CardLayouts>
         <Collide index="Locust" value="1"/>
         <Collide index="Phased" value="1"/>
@@ -569,10 +739,11 @@
         <Food value="6"/>
         <Collide index="Locust" value="1"/>
         <Collide index="Phased" value="1"/>
-        <SubgroupPriority value="32"/>
+        <SubgroupPriority value="28"/>
         <CardLayouts index="0">
             <LayoutButtons index="10" removed="1"/>
         </CardLayouts>
+        <Sight value="12"/>
     </CUnit>
     <CUnit id="Hellion">
         <Collide index="Locust" value="1"/>
@@ -597,12 +768,13 @@
         <SubgroupPriority value="93"/>
         <WeaponArray Link="HighTemplarWeapon"/>
         <AbilArray Link="attack"/>
+        <Speed value="2.0156"/>
     </CUnit>
     <CUnit id="Hive">
         <Food value="6"/>
         <Collide index="Locust" value="1"/>
         <Collide index="Phased" value="1"/>
-        <SubgroupPriority value="28"/>
+        <SubgroupPriority value="32"/>
         <CardLayouts index="0">
             <LayoutButtons index="8" removed="1"/>
         </CardLayouts>
@@ -825,6 +997,9 @@
         <CostResource index="Minerals" value="15"/>
         <ScoreMake value="15"/>
         <ScoreKill value="15"/>
+        <ShieldsStart value="30"/>
+        <ShieldsMax value="30"/>
+        <AttackTargetPriority value="19"/>
     </CUnit>
     <CUnit id="Lair">
         <Food value="6"/>
@@ -834,6 +1009,7 @@
         <CardLayouts index="0">
             <LayoutButtons index="10" removed="1"/>
         </CardLayouts>
+        <Sight value="12"/>
     </CUnit>
     <CUnit id="LocustMPFlying">
         <FlagArray index="UseLineOfSight" value="1"/>
@@ -994,6 +1170,7 @@
         <SubgroupPriority value="36"/>
         <GlossaryStrongArray index="1" value="LurkerMP"/>
         <FlagArray index="UseLineOfSight" value="1"/>
+        <Speed value="2.0156"/>
     </CUnit>
     <CUnit id="ObserverSiegeMode" parent="Observer">
         <Speed value="0"/>
@@ -1026,6 +1203,7 @@
         <GlossaryWeakArray value="Overseer"/>
         <GlossaryWeakArray value="Observer"/>
         <FlagArray index="UseLineOfSight" value="1"/>
+        <AttackTargetPriority value="20"/>
     </CUnit>
     <CUnit id="OrbitalCommand">
         <Food value="15"/>
@@ -1182,7 +1360,7 @@
             <LayoutButtons Face="BurrowUp" Type="AbilCmd" AbilCmd="BurrowInfestorUp,Execute" Row="2" Column="4"/>
             <LayoutButtons Face="BurrowUp" Type="AbilCmd" AbilCmd="BurrowUltraliskUp,Execute" Row="2" Column="4"/>
         </CardLayouts>
-        <BehaviorArray Link="QueenMustBeOnCreep"/>
+        <BehaviorArray Link="OnCreep"/>
     </CUnit>
     <CUnit id="QueenBurrowed">
         <SubgroupPriority value="101"/>
@@ -1561,9 +1739,9 @@
     </CUnit>
     <CUnit id="StarportTechLab">
         <CardLayouts index="0">
-            <LayoutButtons index="2" Face="ResearchBansheeCloak" AbilCmd="StarportTechLabResearch,Research1" Column="1"/>
-            <LayoutButtons index="3" Face="ResearchRavenEnergyUpgrade" AbilCmd="StarportTechLabResearch,Research4" Column="0"/>
-            <LayoutButtons index="4" Face="BansheeSpeed" AbilCmd="StarportTechLabResearch,Research10" Column="2"/>
+            <LayoutButtons index="2" Face="ResearchBansheeCloak" AbilCmd="StarportTechLabResearch,Research1"/>
+            <LayoutButtons index="3" Face="BansheeSpeed" AbilCmd="StarportTechLabResearch,Research10" Column="1"/>
+            <LayoutButtons index="4" removed="1"/>
             <LayoutButtons index="5" removed="1"/>
             <LayoutButtons index="6" removed="1"/>
             <LayoutButtons index="7" removed="1"/>
@@ -1732,6 +1910,9 @@
             <LayoutButtons Face="BurrowUp" Type="AbilCmd" AbilCmd="BurrowInfestorUp,Execute" Row="2" Column="4"/>
             <LayoutButtons Face="BurrowUp" Type="AbilCmd" AbilCmd="BurrowUltraliskUp,Execute" Row="2" Column="4"/>
         </CardLayouts>
+        <Radius value="0.875"/>
+        <InnerRadius value="0.6875"/>
+        <MinimapRadius value="0.875"/>
     </CUnit>
     <CUnit id="UltraliskBurrowed">
         <SubgroupPriority value="88"/>
@@ -1762,6 +1943,9 @@
             <LayoutButtons Face="BurrowUp" Type="AbilCmd" AbilCmd="BurrowInfestorUp,Execute" Row="2" Column="4"/>
             <LayoutButtons Face="BurrowUp" Type="AbilCmd" AbilCmd="BurrowUltraliskUp,Execute" Row="2" Column="4"/>
         </CardLayouts>
+        <Radius value="0.875"/>
+        <InnerRadius value="0.6875"/>
+        <MinimapRadius value="0.875"/>
     </CUnit>
     <CUnit id="UltraliskCavern">
         <Collide index="Locust" value="1"/>
@@ -2055,6 +2239,7 @@
         <SubgroupPriority value="68"/>
         <GlossaryWeakArray index="0" value="HellionTank"/>
         <CardLayouts index="0">
+            <LayoutButtons index="5" AbilCmd="MorphToBaneling,Execute"/>
             <LayoutButtons index="6" Column="3"/>
             <LayoutButtons Face="BurrowDown" Type="AbilCmd" AbilCmd="BurrowDroneDown,Execute" Row="2" Column="3"/>
             <LayoutButtons Face="BurrowDown" Type="AbilCmd" AbilCmd="BurrowZerglingDown,Execute" Row="2" Column="3"/>
@@ -2079,6 +2264,106 @@
             <LayoutButtons Face="BurrowUp" Type="AbilCmd" AbilCmd="BurrowInfestorUp,Execute" Row="2" Column="4"/>
             <LayoutButtons Face="BurrowUp" Type="AbilCmd" AbilCmd="BurrowUltraliskUp,Execute" Row="2" Column="4"/>
         </CardLayouts>
+        <AbilArray index="5" Link="MorphToBaneling"/>
+    </CUnit>
+    <CUnit id="Zergling2">
+        <DeathRevealRadius value="3"/>
+        <Race value="Zerg"/>
+        <Mob value="Multiplayer"/>
+        <FlagArray index="PreventDestroy" value="1"/>
+        <FlagArray index="UseLineOfSight" value="1"/>
+        <FlagArray index="ArmySelect" value="1"/>
+        <PlaneArray index="Ground" value="1"/>
+        <Collide index="Ground" value="1"/>
+        <Collide index="ForceField" value="1"/>
+        <Collide index="Locust" value="1"/>
+        <Collide index="Small" value="1"/>
+        <Attributes index="Light" value="1"/>
+        <Attributes index="Biological" value="1"/>
+        <LifeStart value="35"/>
+        <LifeMax value="35"/>
+        <LifeRegenRate value="0.2734"/>
+        <LifeArmorName value="Unit/LifeArmorName/ZergGroundArmor"/>
+        <Speed value="2.9531"/>
+        <SpeedMultiplierCreep value="1.3"/>
+        <Acceleration value="1000"/>
+        <LateralAcceleration value="46.0625"/>
+        <StationaryTurningRate value="999.8437"/>
+        <TurningRate value="999.8437"/>
+        <Sight value="8"/>
+        <Food value="-0.5"/>
+        <CostCategory value="Army"/>
+        <CostResource index="Minerals" value="25"/>
+        <AttackTargetPriority value="20"/>
+        <DamageDealtXP value="1"/>
+        <DamageTakenXP value="1"/>
+        <KillXP value="5"/>
+        <AbilArray Link="stop"/>
+        <AbilArray Link="attack"/>
+        <AbilArray Link="move"/>
+        <AbilArray Link="que1"/>
+        <AbilArray Link="BurrowZerglingDown"/>
+        <AbilArray Link="MorphToBaneling"/>
+        <WeaponArray Link="Claws"/>
+        <CardLayouts>
+            <LayoutButtons Face="Move" Type="AbilCmd" AbilCmd="move,Move" Row="0" Column="0"/>
+            <LayoutButtons Face="Stop" Type="AbilCmd" AbilCmd="stop,Stop" Row="0" Column="1"/>
+            <LayoutButtons Face="MoveHoldPosition" Type="AbilCmd" AbilCmd="move,HoldPos" Row="0" Column="2"/>
+            <LayoutButtons Face="Attack" Type="AbilCmd" AbilCmd="attack,Execute" Row="0" Column="4"/>
+            <LayoutButtons Face="MovePatrol" Type="AbilCmd" AbilCmd="move,Patrol" Row="0" Column="3"/>
+            <LayoutButtons Face="Baneling" Type="AbilCmd" AbilCmd="MorphToBaneling,Train1" Row="2" Column="0"/>
+            <LayoutButtons Face="BurrowDown" Type="AbilCmd" AbilCmd="BurrowZerglingDown,Execute" Row="2" Column="3"/>
+            <LayoutButtons Face="BurrowDown" Type="AbilCmd" AbilCmd="BurrowDroneDown,Execute" Row="2" Column="3"/>
+            <LayoutButtons Face="BurrowDown" Type="AbilCmd" AbilCmd="BurrowZerglingDown,Execute" Row="2" Column="3"/>
+            <LayoutButtons Face="BurrowDown" Type="AbilCmd" AbilCmd="BurrowBanelingDown,Execute" Row="2" Column="3"/>
+            <LayoutButtons Face="BurrowDown" Type="AbilCmd" AbilCmd="BurrowRoachDown,Execute" Row="2" Column="3"/>
+            <LayoutButtons Face="BurrowDown" Type="AbilCmd" AbilCmd="BurrowHydraliskDown,Execute" Row="2" Column="3"/>
+            <LayoutButtons Face="BurrowDown" Type="AbilCmd" AbilCmd="BurrowRavagerDown,Execute" Row="2" Column="3"/>
+            <LayoutButtons Face="BurrowDown" Type="AbilCmd" AbilCmd="MorphToSwarmHostBurrowedMP,Execute" Row="2" Column="3"/>
+            <LayoutButtons Face="BurrowDown" Type="AbilCmd" AbilCmd="BurrowQueenDown,Execute" Row="2" Column="3"/>
+            <LayoutButtons Face="BurrowDown" Type="AbilCmd" AbilCmd="BurrowInfestorTerranDown,Execute" Row="2" Column="3"/>
+            <LayoutButtons Face="BurrowDown" Type="AbilCmd" AbilCmd="BurrowInfestorDown,Execute" Row="2" Column="3"/>
+            <LayoutButtons Face="BurrowDown" Type="AbilCmd" AbilCmd="BurrowUltraliskDown,Execute" Row="2" Column="3"/>
+            <LayoutButtons Face="BurrowUp" Type="AbilCmd" AbilCmd="BurrowDroneUp,Execute" Row="2" Column="4"/>
+            <LayoutButtons Face="BurrowUp" Type="AbilCmd" AbilCmd="BurrowZerglingUp,Execute" Row="2" Column="4"/>
+            <LayoutButtons Face="BurrowUp" Type="AbilCmd" AbilCmd="BurrowBanelingUp,Execute" Row="2" Column="4"/>
+            <LayoutButtons Face="BurrowUp" Type="AbilCmd" AbilCmd="BurrowRoachUp,Execute" Row="2" Column="4"/>
+            <LayoutButtons Face="BurrowUp" Type="AbilCmd" AbilCmd="BurrowHydraliskUp,Execute" Row="2" Column="4"/>
+            <LayoutButtons Face="BurrowUp" Type="AbilCmd" AbilCmd="BurrowRavagerUp,Execute" Row="2" Column="4"/>
+            <LayoutButtons Face="BurrowUp" Type="AbilCmd" AbilCmd="MorphToSwarmHostMP,Execute" Row="2" Column="4"/>
+            <LayoutButtons Face="BurrowUp" Type="AbilCmd" AbilCmd="BurrowQueenUp,Execute" Row="2" Column="4"/>
+            <LayoutButtons Face="BurrowUp" Type="AbilCmd" AbilCmd="BurrowInfestorTerranUp,Execute" Row="2" Column="4"/>
+            <LayoutButtons Face="BurrowUp" Type="AbilCmd" AbilCmd="BurrowInfestorUp,Execute" Row="2" Column="4"/>
+            <LayoutButtons Face="BurrowUp" Type="AbilCmd" AbilCmd="BurrowUltraliskUp,Execute" Row="2" Column="4"/>
+        </CardLayouts>
+        <Radius value="0.375"/>
+        <SeparationRadius value="0.375"/>
+        <CargoSize value="1"/>
+        <ScoreMake value="25"/>
+        <ScoreKill value="25"/>
+        <ScoreResult value="BuildOrder"/>
+        <SubgroupPriority value="68"/>
+        <MinimapRadius value="0.375"/>
+        <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
+        <TacticalAI value="Zergling"/>
+        <GlossaryCategory value="Unit/Category/ZergUnits"/>
+        <GlossaryPriority value="50"/>
+        <GlossaryStrongArray value="Marauder"/>
+        <GlossaryStrongArray value="Hydralisk"/>
+        <GlossaryStrongArray value="Stalker"/>
+        <GlossaryWeakArray value="HellionTank"/>
+        <GlossaryWeakArray value="Baneling"/>
+        <GlossaryWeakArray value="Colossus"/>
+        <HotkeyCategory value="Unit/Category/ZergUnits"/>
+        <KillDisplay value="Always"/>
+        <RankDisplay value="Always"/>
+        <Fidget>
+            <ChanceArray index="Anim" value="33"/>
+            <ChanceArray index="Idle" value="33"/>
+            <ChanceArray index="Turn" value="33"/>
+        </Fidget>
+        <TauntDuration index="Cheer" value="5"/>
+        <TauntDuration index="Dance" value="5"/>
     </CUnit>
     <CUnit id="ZerglingBurrowed">
         <SubgroupPriority value="68"/>
@@ -2420,6 +2705,8 @@
         <GlossaryWeakArray index="2" value="HighTemplar"/>
         <GlossaryStrongArray index="1" value="LurkerMP"/>
         <FlagArray index="UseLineOfSight" value="1"/>
+        <EnergyStart value="75"/>
+        <CostResource index="Vespene" value="150"/>
     </CUnit>
     <CUnit id="RavenScramblerMissile" parent="MISSILE_INVULNERABLE">
         <Race value="Terr"/>

--- a/mods/voidmulti.sc2mod/base.sc2data/gamedata/upgradedata.xml
+++ b/mods/voidmulti.sc2mod/base.sc2data/gamedata/upgradedata.xml
@@ -46,7 +46,7 @@
         <Icon value="Assets\Textures\btn-upgrade-terran-hyperflightrotors.dds"/>
         <Alert value="ResearchComplete"/>
         <Race value="Terr"/>
-        <ScoreAmount value="200"/>
+        <ScoreAmount value="250"/>
         <ScoreResult value="BuildOrder"/>
         <EffectArray Reference="Unit,Banshee,Speed" Value="1"/>
         <EditorCategories value="Race:Terran,UpgradeType:Talents"/>
@@ -548,11 +548,9 @@
         <ScoreAmount value="200"/>
         <ScoreResult value="BuildOrder"/>
         <!--EffectArray Reference="Effect,CycloneAirWeaponDamage,Amount" Value="6"/-->
-        <EffectArray Reference="Effect,CycloneAirWeaponDamage,AttributeBonus[Armored]" Value="20"/>
+        <EffectArray Reference="Effect,CycloneAirWeaponDamage,Amount" Value="10"/>
         <!--EffectArray Reference="Effect,CycloneWeaponDamage,Amount" Value="5"/-->
-        <EffectArray Reference="Effect,CycloneWeaponDamage,AttributeBonus[Armored]" Value="20"/>
-        <EffectArray Operation="Set" Reference="Button,LockOn,AlertTooltip" Value="Button/Tooltip/LockOnUpgraded"/>
-        <EffectArray Operation="Set" Reference="Button,LockOn,Tooltip" Value="Button/Tooltip/LockOnUpgraded"/>
+        <EffectArray Reference="Effect,CycloneWeaponDamage,Amount" Value="10"/>
         <EditorCategories value="Race:Terran,UpgradeType:Talents"/>
         <AffectedUnitArray value="Cyclone"/>
     </CUpgrade>
@@ -692,7 +690,7 @@
         <Race value="Zerg"/>
         <ScoreAmount value="200"/>
         <ScoreResult value="BuildOrder"/>
-        <EffectArray Operation="Set" Reference="Unit,Hydralisk,Speed" Value="2.812500"/>
+        <EffectArray Reference="Unit,Hydralisk,Speed" Value="0.750000"/>
         <EditorCategories value="Race:Zerg,UpgradeType:Talents"/>
         <AffectedUnitArray value="Hydralisk"/>
         <AffectedUnitArray value="HydraliskBurrowed"/>

--- a/mods/voidmulti.sc2mod/base.sc2data/gamedata/validatordata.xml
+++ b/mods/voidmulti.sc2mod/base.sc2data/gamedata/validatordata.xml
@@ -99,7 +99,7 @@
     </CValidatorPlayerRequirement>
     <CValidatorCombine id="HarvestableResourceandNearbyTownhall">
         <Type value="And"/>
-        <CombineArray value="HarvestableResources"/>
+        <CombineArray value="Minerals"/>
         <CombineArray value="PlayerTownhallwithin10"/>
     </CValidatorCombine>
     <CValidatorUnitCompareBehaviorCount id="LarvaNotConjoined">
@@ -452,6 +452,7 @@
         <CombineArray value="ChannelSnipeBehaviorValidator"/>
         <CombineArray value="ChannelSnipeCasterFilters"/>
         <CombineArray value="ChannelSnipeTargetFilters"/>
+        <CombineArray value="ChannelSnipeRange"/>
     </CValidatorCombine>
     <CValidatorUnitCompareBehaviorCount id="ChannelSnipeRefundValidator">
         <WhichUnit Value="Caster"/>
@@ -507,6 +508,11 @@
         <Compare value="GT"/>
         <Behavior value="TakenDamage"/>
     </CValidatorUnitCompareBehaviorCount>
+    <CValidatorLocationCompareRange id="ChannelSnipeRange">
+        <WhichLocation Value="TargetUnit"/>
+        <Compare value="LT"/>
+        <Range value="13.5"/>
+    </CValidatorLocationCompareRange>
     <CValidatorLocationCompareRange id="ChargeDamageDistance">
         <WhichLocation Value="SourceUnit"/>
         <Value Effect="Charge" Value="TargetUnit"/>
@@ -556,6 +562,10 @@
         <Value value="TempestDisruptionSphereAttackMissile"/>
         <Find value="0"/>
     </CValidatorUnitType>
+    <CValidatorUnitCompareBehaviorCount id="NotHaveBatteryCooldownBehavior">
+        <WhichUnit Value="Caster"/>
+        <Behavior value="BatteryAcquireTargetCooldown"/>
+    </CValidatorUnitCompareBehaviorCount>
     <CValidatorUnitCompareBehaviorCount id="NotHaveBeamTargetCDBehavior">
         <Behavior value="BeamTargetCD"/>
         <RequireCasterUnit Value="Caster"/>

--- a/mods/voidmulti.sc2mod/base.sc2data/gamedata/weapondata.xml
+++ b/mods/voidmulti.sc2mod/base.sc2data/gamedata/weapondata.xml
@@ -99,11 +99,16 @@
         <Effect value="DisruptionBeam"/>
         <LegacyOptions index="CanRetargetWhileChanneling" value="1"/>
     </CWeaponLegacy>
+    <CWeaponLegacy id="FusionCutter">
+        <LegacyOptions index="NoDeceleration" value="1"/>
+        <AllowedMovement value="Slowing"/>
+    </CWeaponLegacy>
     <CWeaponLegacy id="GuassRifle">
         <MinScanRange value="5.5"/>
     </CWeaponLegacy>
     <CWeaponLegacy id="HydraliskMelee">
-        <Period value="0.75"/>
+        <Period value="0.825"/>
+        <DamagePoint value="0.14"/>
     </CWeaponLegacy>
     <CWeaponLegacy id="InfernalFlameThrower">
         <MinScanRange value="5.5"/>
@@ -112,8 +117,15 @@
         <MinScanRange value="5.5"/>
         <TargetFilters value="Ground,Visible;Missile,Stasis,Dead,Hidden,Invulnerable"/>
     </CWeaponLegacy>
+    <CWeaponStrafe id="InterceptorBeam">
+        <LoiterInnerRadius value="3"/>
+        <LoiterRadius value="5"/>
+    </CWeaponStrafe>
     <CWeaponLegacy id="JavelinMissileLaunchers">
         <MinScanRange value="10.5"/>
+    </CWeaponLegacy>
+    <CWeaponLegacy id="KaiserBlades">
+        <RangeSlop value="1.4"/>
     </CWeaponLegacy>
     <CWeaponLegacy id="LanceMissileLaunchers">
         <Period value="1.28"/>
@@ -141,6 +153,7 @@
     <CWeaponLegacy id="NeedleSpines">
         <Period value="0.825"/>
         <MinScanRange value="5.5"/>
+        <DamagePoint value="0.14"/>
     </CWeaponLegacy>
     <CWeaponLegacy id="Oracle">
         <Options index="Hidden" value="1"/>
@@ -176,6 +189,10 @@
     <CWeaponLegacy id="ParasiteSpore">
         <DamagePoint value="0.0625"/>
     </CWeaponLegacy>
+    <CWeaponLegacy id="ParticleBeam">
+        <LegacyOptions index="NoDeceleration" value="1"/>
+        <AllowedMovement value="Slowing"/>
+    </CWeaponLegacy>
     <CWeaponLegacy id="ParticleDisruptors">
         <MinScanRange value="6.5"/>
         <Period value="1.87"/>
@@ -191,6 +208,10 @@
     <CWeaponLegacy id="RavagerWeapon">
         <Period value="1.6"/>
         <MinScanRange value="6.5"/>
+    </CWeaponLegacy>
+    <CWeaponLegacy id="Spines">
+        <LegacyOptions index="NoDeceleration" value="1"/>
+        <AllowedMovement value="Slowing"/>
     </CWeaponLegacy>
     <CWeaponLegacy id="Talons">
         <MinScanRange value="5.5"/>


### PR DESCRIPTION
### Summary

[official patch notes](https://news.blizzard.com/en-us/starcraft2/23891308/starcraft-ii-5-0-11-ptr-patch-notes)

## Undocumented changes/bugs
- ### Zerg
  - Lurker's Unburrow random starting delay was changed from [0, 0.5] to [0, 0] => on average 180ms faster
  - Lurker's Burrow random starting delay was changed from [0, 0.25] to [0, 0.125] => on average 45ms faster
  - Morphing to a Lurker's random delay reduced from [0,0.5] to [0,0]
    - Was this necessary for the smart command cancellation?
  - Morphing to a Ravager's random starting delay was reduced from [0, 0.5] to [0, 0]
    - Was this necessary for the smart command cancellation?
  - Swarm Hosts can now spawn Locusts with a target point without loosing existing orders. The ability is now flagged as transient [(video by Leisvan)](https://twitter.com/leisvanCT/status/1602035910912131075)
  - Lurker's attack was altered
    - Removed CasterIsAttacking validator from Lurker attack's spine splash damage hits
    - Added channeled and effectFailure flag to Lurker's attack's persistent effect
      - Why were these two aspects changed?
      - This has two most likely undesired side effects:
        - Changing the attack target while the persistent effect is active causes it to end. So, changing the attack target will cancel the current attack! You can make your Lurker not damage anything by constantly switching between two targets 😆 
        - When targeting a friendly target, you can now order Stop to cancel the attack mid-travel
  - Hatchery and Hive's subgroup priority swapped (Hatchery to 28, Hive to 32). This alters which units receive selection priority when multiple units are selected
    - This causes command card buttons for the morph to Lair to disappear when multiple are selected as the Hatchery is not selected first anymore!
    picture by [TheG on Blizzard's SC forums](https://us.forums.blizzard.com/en/sc2/t/a-few-bugs-in-the-new-5011-patch/25997/10)
![image](https://user-images.githubusercontent.com/5763784/206924752-861894d8-7079-41c7-ab6c-1453fe889831.png)
  - Queen Transfusion on-creep text was broken due to a pointless behavior and requirement swap (both do exactly the same, just the Queen's one had a text for this error case) ![image](https://user-images.githubusercontent.com/5763784/206874446-b4626c20-9667-47ae-bd06-c38f4ffc3db2.png)
  - The list of Zerg units in the help menu has some holes now. These were created by two new unit types added: Zergling2 and Baneling2. Both are unused and have no unit actor (thanks to Spectre from sc2mapster discord for the connection to missing actors causing missing buttons)
![image](https://user-images.githubusercontent.com/5763784/206882072-0d8bbcf5-c259-4b34-a102-c5f755d2dcf1.png)
  - Swarm Hosts can now immediately receive orders after the Unburrow command was given. For example, to move to a certain point

- ### Terran
  - Banshee's attack's rockets spawn ~100ms earlier (0.15 seconds earlier on normal game speed). The first rocket now spawns without delay
  - Raven's Anti-Armor-Missile tints the affected units in another color that is more yellow than orange. The color changed from 255,100,0 to 255,187,85
from ![image](https://user-images.githubusercontent.com/5763784/206874696-cd8dde98-d95b-472b-9e3d-e48cc3639feb.png) to ![image](https://user-images.githubusercontent.com/5763784/206874681-3d7d67db-8aa3-4ed8-8699-04599ba06a2e.png)
  - Raven's Interference Matrix adds the Interference Matrix's duration to the cooldown of Immortal's Barrier, if it is on cooldown after the matrix's effect expired
    - The cooldown addition feels arbitrary. What does this fix? Does this work as intended in all scenarios, e.g. when the cooldown expires while the matrix is active? I find it odd that it adds cooldown duration after the matrix ended, but only when the Barrier is still on cooldown

- ### Protoss
  - Shield Battery's recharge's impact model is now hidden in the fog of war
  - Interceptor attack impact sounds are slightly louder (Volume min,max increased from -11,-10 to -9,-8)
  - Interceptor attack firing sounds are slightly louder (Volume min,max increased from -10,-6 to -8,-5)
  - fixed Battery Overcharge's range indicator showing range 9 when the ability had range 10. This is only a visual change for the circle that appears around the Nexus


## Bugs in documented changes
- Observer and Ultralisk's model size changes do not work with skins since the default skin's model entry was edited and all skins have their own model entries. The base model entry, or the actor should have been edited, or alternatively all skin model settings individually
  -  [Creager on teamliquid](https://tl.net/forum/starcraft-2/604131-balance-patch-5011-ptr-patch-notes?page=10#194) verified this bug:
![image](https://user-images.githubusercontent.com/5763784/206876250-b12df807-3773-4e9a-8ba5-a02767d816c5.png)
[Leisvan](https://twitter.com/leisvanCT/status/1601730103741861888) replicated the issue as well (although only in the editor, but I see no magical way how this is not wrong in the game as well):
![image](https://user-images.githubusercontent.com/5763784/206881132-6a6a400b-dfe8-456a-bf48-e01ea14f00f7.png)
- Female Ghost skins have no cancel button for snipe. Their unit "GhostAlternate" lacks the snipe ability (it still works due to morph-inheritance of abilities, but usually every ability is defined in every unit), and the command card does not use the SnipeCancel for the button. Instead an non-existing ability is referenced. This causes the button to not appear and the shortcut to not work!
[ingoschlegelmilch](https://github.com/Ahli/sc2xml/issues/2) verified that this is not working for the female Ghost skin:
![SC2_x64_female_ghost_short](https://user-images.githubusercontent.com/25961571/206877925-f34cdcea-af4f-483b-be8f-9d75a5c2393e.gif)
  - Therefore, the special, rare-spawning Nova skin (GhostAlternateNova) does not display the Snipe's cancel button as well. Instead of the correct ability SnipeCancel, an non-existing ability is referenced
- all Ghost units (Ghost, GhostAlternate, GhostAlternateNova) still display the Enhanced Shockwaves upgrade on their command cards
![image](https://user-images.githubusercontent.com/5763784/206882473-6b7fbef3-d74c-4597-bf68-0e86b007a977.png)
- Battery Overcharge still recharges at a rate of 200%. The behavior "BatteryOvercharge" still has a "HealDealtMultiplier" of 2

## Patch notes are wrong/inaccurate
- Roach -> Ravager morph time increased from 8.6 to 12.1 seconds (from 12 to 17 on normal speed). Patch notes are wrong. They falsely stated from 8.6 to 12.9 seconds. It is ~0.75s faster than that
- Steady Targeting (Snipe) will break at exactly 13.5 range while the patch notes indicate that it needs to be more than 13.5 range
- Interceptor flying radius around target increased by 1. The patch notes did not state by how much
- The Liberator received improvements for queuing orders not only when unsieging, but also when sieging
- Cyclone's Lock On no longer targets Zerg Eggs without a manual order. The correct term would be "Zerg Cocoon" instead of "Zerg Egg". This only refers to the "eggs" from Larvae. Other "eggs" are still automatically targeted

## Potential bugs (need verification)
- Unburrow might make units visible to the enemy faster as the morph's stats duration changed to 0 for Drone. Hydralisk, Infestor, Queen, Roach. The Lurker, Baneling, Zergling and Ultralisk already had this set to 0. Maybe this does not affect anything, though

## Side effects
- Broodling duration change affects Broodlings from structures as well. Could be made separate since these Broodlings are usually very impactless and would now accomplish even less
- Enhanced Shockwaves upgrade can still be researched by AI and hackers as these do not require the command card button. Consider removing ability entries that should not be executable. Do you not remember [warping in Immortals in WoL](https://youtu.be/boyZjC_mj68?t=470) or computer players throwing Infested Terrans after the patch "removed" them from the Infestor?
- The Interceptor flying area radius was raised. Could this have implications to their DPS? Maybe they will fire less because they have to fly further and maybe outside their weapon range. I do not understand what the two values (LoiterRadius, InnerLoiterRadius) actually mean, so I cannot say what will happen here
- Ultralisk's radius reduction will cause the area of its area damage to shrink by a tiny amount. The area damage is offset by the Ultra's radius, so the area in the half circle of area damage is smaller.
However, the smaller radius should help the Ultra much more than the smaller area nerfs it. I mention this for clarity. Maybe someone can test this with immobile Zerglings
- **Units hit by a stasis trap can be pushed around** because movement is not suppressed anymore. Maybe that can be fixed with setting max move speed to 0 or 0.001 during stasis. If someone has a better fix suggestion, let me know and I add it here. Reported by throwaway-link on reddit
- The Hatchery creep spawn rate is causing Larva to spawn on creep nearby a Hatchery that finishes morphing. Usually, Larva spawn on the creep generated close to the Hatchery. Now it looks like the Hatch attempts to spawn the Larva before the own creep is generated. Here, a Hatchery finishes close to existing creep and the Larva is spawned on the previously existing creep:
![image](https://user-images.githubusercontent.com/5763784/206957224-2892abba-dfc3-4b27-a257-3f2a442182b5.png)
![image](https://user-images.githubusercontent.com/5763784/206957243-0ea3027c-7ad1-4548-b283-7331694ae5f5.png)
I could fix the issue by using a different period. The closest good values are 0.352 and 0.346. Please use one of these instead!
- The new Baneling morph ability should enable "IgnoreCollision" and "ignorePlacement". The Ravager morph does that as well. Else, there could be issues with the morph not finishing due to some collisions

## Changes that could be done for more units
- Factory's maximum spawn radius increased from 2 to 3. Other unit production structures have a spawn range of 2 (besides Larva with 4, but eggs pile up in one place). Why is this Factory specific and not raised to 3 for all producing structures (Barracks, Starport, CC, Hatchery, Nexus, Gateway, Robotics Facility, Stargate)?

## Further bug fixes that this patch could include as well
- Shield Battery's range indicator is not visible when you target the overcharge yourself via its command card button. It is only visible when you want to build one
![Screenshot2022-12-12 19_48_56](https://user-images.githubusercontent.com/5763784/207129775-18f98013-84f8-4f76-9dc1-898e0c2a197b.jpg)
![Screenshot2022-12-12 19_48_50](https://user-images.githubusercontent.com/5763784/207129783-862be9a2-e192-407c-939f-136d0802e796.jpg)
Here is how it is added for the ability's targeting mode and mouse hover over the button:
``` xml
    <CActorRange id="ShieldBatteryRange">
        <On Terms="Abil.ShieldBatteryRechargeEx5.TargetOn" Send="Create"/>
        <On Terms="Abil.ShieldBatteryRechargeEx5.TargetOff" Send="Destroy"/>
        <On Terms="Abil.ShieldBatteryRechargeEx5.ButtonHoverOn" Send="Create"/>
        <On Terms="Abil.ShieldBatteryRechargeEx5.ButtonHoverOff" Send="Destroy"/>
     </CActorRange>
```
- Thor's default mode does not collide with Locusts. The 2nd mode does. The collision flag needs to be ticked:
``` xml
    <CUnit id="ThorAP">
        <Collide index="Locust" value="1"/>
    </CUnit>
```
- Disruptor and Archon's minimap radius is smaller than its unit radius (collision with units). These values should match
- Thor in high impact payload mode with Tyrador skin is missing the correct attack animation. This leads to the Thor sliding as well. The correct animations can be added easily in the editor: [FIX with Video and Test Map](https://github.com/Ahli/sc2xml/issues/5)
- Liberator does not create ripples in water. Required water height varies greatly per unit. [FIX with Test Map](https://github.com/Ahli/sc2xml/issues/4)
- Protoss Ihan-Rii skin's warp in death model is terrible for players as it can easily be confused with finished structures. [video of the models](https://www.youtube.com/watch?v=AVpr1tI00uM)  [workaround reverting the model](https://github.com/Ahli/sc2xml/issues/6)
- Protoss Ihan-Rii skin's Nexus' Warp In model has no attachment points. That causes no shield impact model to be played on attacks and the game displays an error in tests:
`CActorShield[ProtossShieldFull] Could not find e_attachShield or a dynamic shield attach on unit [ 44 1] CActorUnit[Nexus] with model Nexus_Ihanrii_WarpIn.m3.`. Since the model has 0 attachment points, you cannot work around this defining a dynamic shield attack in the model's settings. [video](https://www.youtube.com/watch?v=GwwL8SQNYpQ)
- Tyrador Fusion Core model looks always like completed during construction due to animation issues. In addition, when starting a research, the model does not look "busy" for the first 1.1 second. [documentation with exact animation names, video and screenshots](https://github.com/Ahli/sc2xml/issues/10)

I will abstain from listing wrong upgrade scores and outdated unit descriptions :)

## Bugs potentially not added in this patch
- Bigger units stack and block each other in chokes created by buildings [(video)](https://www.youtube.com/watch?v=S8EVcVaJ7Js). Here, this happens with the new Ultralisks, Swarm Hosts and Ravagers as well, so this is likely nothing new
- changing game settings might be only accepted once (set health bars to always, change it back and the setting did not stick anymore). Is this PTR specific?

## TODO
- verify potentially broken scenarios
- Ultralisk's death model changed. What is the impact? ragdolls fly further or less? less sliding on ground? more sliding on ground?
- research more known bugs (on LIVE and on PTR)
  - big units stacking in 1 tile chokes between buildings (e.g. Archon, Ultralisk, Ravager, Swarm Host... most likely it has always been like this)
  - make water ripples not spawn on cliff edges

Btw, you can assist me with this!
Tell me about the bugs the multiplayer gameplay runs into and we can try to come up with a fix or a detailed issue explanation to assist Blizzard